### PR TITLE
Add Docker file and instructions to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR ~
+ARG SYMENGINE_INSTALL_DIR=/usr/local
+ARG NEST_INSTALL_DIR=/usr/local
+
+# 0) install dependencies and clone repository
+
+RUN apt-get update && apt-get install -y \
+	cmake \
+	git \
+	libgmp-dev \
+	build-essential\
+	ghostscript dvipng\
+	texlive texlive-latex-extra\
+	python3-pip \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/Happy-Algorithms-League/e2l-cgp-snn.git \
+	&& cd e2l-cgp-snn \
+	&& git checkout 02bd825
+RUN pip3 install -r e2l-cgp-snn/requirements.txt
+RUN pip3 install --upgrade cmake
+RUN rm /usr/bin/python
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# 1) install symengine
+
+RUN git clone https://github.com/symengine/symengine.git \
+	&& cd symengine  \
+	&& mkdir build && cd build \
+	&& cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH="${SYMENGINE_INSTALL_DIR}" .. \
+	&& make && make install \
+	&& ctest \
+	&& cd && rm -Rf symengine
+
+# 2, 3 and 4)  install nest version with custom patch
+
+RUN apt-get update && apt-get install -y \
+	cython3 \
+	libgsl-dev \
+	libltdl-dev \
+	libncurses-dev \
+	libreadline-dev \
+	python3-all-dev \
+	python3-numpy \
+	python3-scipy \
+	python3-matplotlib \
+	python3-nose \
+	openmpi-bin \
+	libopenmpi-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/nest/nest-simulator.git \
+	&& cd nest-simulator \
+	&& git checkout 27dc242 \
+	&& git apply ../e2l-cgp-snn/nest/ltl_usrl_us_sympy.patch \
+	&& mkdir build && cd build \
+	&& cmake -Dwith-python=3 -DCMAKE_INSTALL_PREFIX:PATH="${NEST_INSTALL_DIR}" .. \
+	&& make && make install \
+	&& cd && rm -Rf nest-simulator
+RUN echo "source ${NEST_INSTALL_DIR}/bin/nest_vars.sh" >> ~/.bashrc 
+
+# 5) install custom extensions
+
+ENV NEST_MODULE_PATH=/usr/local/lib/nest:$NEST_MODULE_PATH
+ENV SLI_PATH=/usr/local/share/nest/sli:$SLI_PATH
+
+RUN cd e2l-cgp-snn/nest/stdp-homeostatic-synapse-module/ \
+	&& mkdir build && cd build \
+	&& cmake -Dwith-nest="${NEST_INSTALL_DIR}/bin/nest-config" ../ \
+	&& make && make install
+RUN cd e2l-cgp-snn/nest/usrl-synapse-module/ \
+	&& mkdir build && cd build \
+	&& cmake -Dwith-nest="${NEST_INSTALL_DIR}/bin/nest-config" ../ \
+	&& make && make install
+RUN cd e2l-cgp-snn/nest/us-sympy-synapse-module/ \
+	&& mkdir build && cd build \
+	&& cmake -Dwith-nest="${NEST_INSTALL_DIR}/bin/nest-config" -Dwith-symengine="${SYMENGINE_INSTALL_DIR}" ../ \
+	&& make && make install
+RUN cd e2l-cgp-snn/nest/stdp-sympy-synapse-module/ \
+	&& mkdir build && cd build \
+	&& cmake -Dwith-nest="${NEST_INSTALL_DIR}/bin/nest-config" -Dwith-symengine="${SYMENGINE_INSTALL_DIR}" ../ \
+	&& make && make install
+
+ENV PYTHONPATH=/usr/local/lib/python3.6/site-packages/:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/include:$LD_LIBRARY_PATH
+ENV NEST_MODULE_PATH="${NEST_INSTALL_DIR}/lib/nest:$NEST_MODULE_PATH"
+ENV SLI_PATH="${NEST_INSTALL_DIR}/share/nest/sli:$SLI_PATH"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ This repository is organized as follows:
 - `experiments` contains scripts to perform the described experiments
 - `nest` contains custom synapse models and kernel patches for NEST (required to run the experiments)
 
+# Docker container
+
+The easiest way to reproduce the figures and experiments is to use the Dockerfile in this repository. It a Python interpreter with all dependencies installed and a built NEST with all synapse modules compiled. To use it, do the following:
+
+- Build the Docker container (`docker build .`) and run the container in interactive mode.
+- Reproduce the figures:
+
+  ```bash
+  cd e2l-cgp-snn/figures
+  make all  
+  ```
+- Test the NEST synapse modules:
+  Start a Python console and execute:
+  ```python
+  import nest
+
+  
+  nest.Install('usrl_synapse_module')
+  nest.Install('HomeostaticSTDPmodule')
+  nest.Install('stdp_sympy_synapse_module') 
+  nest.Install('us_sympy_synapse_module') 
+  ```
+
 # Prepare your Python environment
 
 Our scripts rely on a few Python packages that you might need to install. These are specified in `requirements.txt`. You can conveniently install them via pip:


### PR DESCRIPTION
Adds the Dockerfile that was provided by @AaronSpieler (see #1 ) and slightly modified to the repository.

To test this, follow the instructions in the README regarding the docker container.
To build and start the container, I did:

```bash
docker build .
docker tag TAG nest_l2l
docker run -ti --rm nest_l2l
```
where `TAG` is the hash of the built docker image.